### PR TITLE
Use right binary name to format code in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "npx rimraf dist && rollup -c",
-    "format": "run -p format:js format:md",
+    "format": "run-p format:js format:md",
     "format:js": "yarn run lint:js --fix",
     "format:md": "yarn run lint:md -- --fix",
     "lint": "run-p lint:js lint:md",


### PR DESCRIPTION
## :construction_worker: Build

6029f66 - build: use right binary name to format code in parallel

## :link: Related

Closes #20

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>