### PR TITLE
build: stop displaying warning when formatting .md files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "npx rimraf dist && rollup -c",
     "format": "run -p format:js format:md",
     "format:js": "yarn run lint:js --fix",
-    "format:md": "yarn run lint:md -- --fix",
+    "format:md": "yarn run lint:md --fix",
     "lint": "run-p lint:js lint:md",
     "lint:js": "eslint --quiet --format=pretty src",
     "lint:md": "eslint --quiet --format=pretty --ext .md .",


### PR DESCRIPTION
## :construction_worker: Build

fd4a635 - build: stop displaying warning when formatting .md files

## :link: Related

Closes #21

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>